### PR TITLE
updated conf.js

### DIFF
--- a/protractor-jasmine-tests/conf.js
+++ b/protractor-jasmine-tests/conf.js
@@ -1,12 +1,13 @@
 const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 exports.config = {
-    sauceUser: process.env.SAUCE_USERNAME,
-    sauceKey: process.env.SAUCE_ACCESS_KEY,
+    //sauceUser: process.env.SAUCE_USERNAME,
+    //sauceKey: process.env.SAUCE_ACCESS_KEY,
     sauceRegion: 'us',
     seleniumAddress: 'https://ondemand.saucelabs.com/wd/hub',
     specs: ['specs/*spec.js'],
 
     onPrepare: async () => {
+        await browser.waitForAngularEnabled(false);
         const caps = await browser.getCapabilities();
         jasmine.getEnv().addReporter(new SpecReporter({
             spec: {
@@ -19,8 +20,10 @@ exports.config = {
             browserName: 'chrome',
             browserVersion: 'latest',
             platformName: 'Windows 10',
-            chromeOptions : { 'w3c' : true },
+            'goog:chromeOptions' : { 'w3c' : true },
             'sauce:options': {
+                username: process.env.SAUCE_USERNAME,
+                accessKey: process.env.SAUCE_ACCESS_KEY,
                 seleniumVersion: '3.141.59',
                 name: 'chrome-protractor-test',
                 build: 'Sample Protractor Tests'
@@ -32,16 +35,16 @@ exports.config = {
             browserVersion: 'latest',
             platformName: 'Windows 10',
             'sauce:options': {
+                username: process.env.SAUCE_USERNAME,
+                accessKey: process.env.SAUCE_ACCESS_KEY,
                 seleniumVersion: '3.141.59',
-                name: 'chrome-protractor-test',
+                name: 'firefox-protractor-test',
                 build: 'Sample Protractor Tests'
             },
             shardTestFiles: true,
             maxInstances: 25
     }],
-
     baseUrl: 'https://www.saucedemo.com',
-
     SELENIUM_PROMISE_MANAGER: false,
 
     onComplete: async () => {

--- a/protractor-jasmine-tests/conf.js
+++ b/protractor-jasmine-tests/conf.js
@@ -1,62 +1,47 @@
 const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 exports.config = {
-    /*sauceUser: process.env.SAUCE_USERNAME,
-    sauceKey: process.env.SAUCE_ACCESS_KEY,*/
+    sauceUser: process.env.SAUCE_USERNAME,
+    sauceKey: process.env.SAUCE_ACCESS_KEY,
     sauceRegion: 'us',
     seleniumAddress: 'https://ondemand.saucelabs.com/wd/hub',
     specs: ['specs/*spec.js'],
 
-    multiCapabilities: [{
-        browserName: 'chrome',
-        version: 'latest',
-        platform: 'Windows 10',
-        name: 'chrome-protractor-test',
-        build: 'Sample Protractor Tests',
-        username: process.env.SAUCE_USERNAME,
-        accessKey: process.env.SAUCE_ACCESS_KEY,
-        shardTestFiles: true,
-        maxInstances: 25
-    },{
-        browserName: 'firefox',
-        version: 'latest',
-        platform: 'Windows 10',
-        name: 'firefox-protractor-test',
-        build: 'Sample Protractor Tests',
-        username: process.env.SAUCE_USERNAME,
-        accessKey: process.env.SAUCE_ACCESS_KEY,
-        shardTestFiles: true,
-        maxInstances: 25
-    }],
-
-    /**
-     * The below version should work for the upcoming Selenium 4 release and w3c protocol,
-     * although currently the protractor webdriver manager can't resolve 'sauce:options'
-     --------------------------------------------------------------------------------
-
-     browserName: 'chrome',
-     browserVersion: 'latest',
-     platformVersion: 'Windows 10',
-     'sauce:options': {
-            username: process.env.SAUCE_USERNAME,
-            accessKey: process.env.SAUCE_ACCESS_KEY,
-            name: 'chrome-protractor-test',
-            build: 'Sample Protractor Tests',
-            seleniumVersion: '3.141.59'
-        },*/
-
-    baseUrl: 'https://www.saucedemo.com',
-
     onPrepare: async () => {
-        await browser.waitForAngularEnabled(false);
         const caps = await browser.getCapabilities();
         jasmine.getEnv().addReporter(new SpecReporter({
             spec: {
                 displayStacktrace: true,
             }
         }));
-    },
+        },
+        framework: 'jasmine',
+        multiCapabilities: [{
+            browserName: 'chrome',
+            browserVersion: 'latest',
+            platformName: 'Windows 10',
+            chromeOptions : { 'w3c' : true },
+            'sauce:options': {
+                seleniumVersion: '3.141.59',
+                name: 'chrome-protractor-test',
+                build: 'Sample Protractor Tests'
+            },
+            shardTestFiles: true,
+            maxInstances: 25
+        },{
+            browserName: 'firefox',
+            browserVersion: 'latest',
+            platformName: 'Windows 10',
+            'sauce:options': {
+                seleniumVersion: '3.141.59',
+                name: 'chrome-protractor-test',
+                build: 'Sample Protractor Tests'
+            },
+            shardTestFiles: true,
+            maxInstances: 25
+    }],
 
-    framework: 'jasmine',
+    baseUrl: 'https://www.saucedemo.com',
+
     SELENIUM_PROMISE_MANAGER: false,
 
     onComplete: async () => {

--- a/protractor-jasmine-tests/conf.js
+++ b/protractor-jasmine-tests/conf.js
@@ -1,58 +1,57 @@
 const SpecReporter = require('jasmine-spec-reporter').SpecReporter;
 exports.config = {
-    //sauceUser: process.env.SAUCE_USERNAME,
-    //sauceKey: process.env.SAUCE_ACCESS_KEY,
-    sauceRegion: 'us',
-    seleniumAddress: 'https://ondemand.saucelabs.com/wd/hub',
-    specs: ['specs/*spec.js'],
+	sauceUser: process.env.SAUCE_USERNAME,
+	sauceKey: process.env.SAUCE_ACCESS_KEY,
+	sauceRegion: 'us',
+	specs: [ 'specs/*spec.js' ],
 
-    onPrepare: async () => {
-        await browser.waitForAngularEnabled(false);
-        const caps = await browser.getCapabilities();
-        jasmine.getEnv().addReporter(new SpecReporter({
-            spec: {
-                displayStacktrace: true,
-            }
-        }));
-        },
-        framework: 'jasmine',
-        multiCapabilities: [{
-            browserName: 'chrome',
-            browserVersion: 'latest',
-            platformName: 'Windows 10',
-            'goog:chromeOptions' : { 'w3c' : true },
-            'sauce:options': {
-                username: process.env.SAUCE_USERNAME,
-                accessKey: process.env.SAUCE_ACCESS_KEY,
-                seleniumVersion: '3.141.59',
-                name: 'chrome-protractor-test',
-                build: 'Sample Protractor Tests'
-            },
-            shardTestFiles: true,
-            maxInstances: 25
-        },{
-            browserName: 'firefox',
-            browserVersion: 'latest',
-            platformName: 'Windows 10',
-            'sauce:options': {
-                username: process.env.SAUCE_USERNAME,
-                accessKey: process.env.SAUCE_ACCESS_KEY,
-                seleniumVersion: '3.141.59',
-                name: 'firefox-protractor-test',
-                build: 'Sample Protractor Tests'
-            },
-            shardTestFiles: true,
-            maxInstances: 25
-    }],
-    baseUrl: 'https://www.saucedemo.com',
-    SELENIUM_PROMISE_MANAGER: false,
+	onPrepare: async () => {
+		await browser.waitForAngularEnabled(false);
+		const caps = await browser.getCapabilities();
+		jasmine.getEnv().addReporter(new SpecReporter({
+			spec: {
+				displayStacktrace: true,
+			}
+		}));
+	},
+	framework: 'jasmine',
+	multiCapabilities: [
+		{
+			browserName: 'chrome',
+			browserVersion: 'latest',
+			platformName: 'Windows 10',
+			'goog:chromeOptions': { 'w3c': true },
+			'sauce:options': {
+				seleniumVersion: '3.141.59',
+				name: 'chrome-protractor-test',
+				build: 'Sample Protractor Tests'
+			},
+			shardTestFiles: true,
+			maxInstances: 25
+		},
+		{
+			browserName: 'firefox',
+			browserVersion: 'latest',
+			platformName: 'Windows 10',
+			'sauce:options': {
+				username: process.env.SAUCE_USERNAME,
+				accessKey: process.env.SAUCE_ACCESS_KEY,
+				seleniumVersion: '3.141.59',
+				name: 'firefox-protractor-test',
+				build: 'Sample Protractor Tests'
+			},
+			shardTestFiles: true,
+			maxInstances: 25
+		},
+	],
+	baseUrl: 'https://www.saucedemo.com',
 
-    onComplete: async () => {
-        let printSessionId = async (jobName) => {
-            let session = await browser.getSession();
-            console.log('SauceOnDemandSessionID=' + session.getId() + ' job-name=' + jobName);
-            };
-        printSessionId("Insert Job Name Here");
-        //await browser.executeScript("sauce:job-result=" + (SpecReporter.valueOf().result());
-    },
+	onComplete: async () => {
+		let printSessionId = async (jobName) => {
+			let session = await browser.getSession();
+			console.log('SauceOnDemandSessionID=' + session.getId() + ' job-name=' + jobName);
+		};
+		printSessionId('Insert Job Name Here');
+		//await browser.executeScript("sauce:job-result=" + (SpecReporter.valueOf().result());
+	},
 };

--- a/protractor-jasmine-tests/conf.js
+++ b/protractor-jasmine-tests/conf.js
@@ -34,8 +34,6 @@ exports.config = {
 			browserVersion: 'latest',
 			platformName: 'Windows 10',
 			'sauce:options': {
-				username: process.env.SAUCE_USERNAME,
-				accessKey: process.env.SAUCE_ACCESS_KEY,
 				seleniumVersion: '3.141.59',
 				name: 'firefox-protractor-test',
 				build: 'Sample Protractor Tests'

--- a/protractor-jasmine-tests/package.json
+++ b/protractor-jasmine-tests/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "jasmine": "^3.4.0",
     "jasmine-spec-reporter": "^4.2.1",
-    "protractor": "^5.4.2",
-    "selenium-webdriver": "^4.0.0-alpha.1",
-    "webdriver-manager": "^12.1.5"
+    "protractor": "6.0.0-beta",
+    "selenium-webdriver": "^4.0.0-alpha.1"
   }
 }

--- a/protractor-jasmine-tests/package.json
+++ b/protractor-jasmine-tests/package.json
@@ -12,7 +12,6 @@
   "dependencies": {
     "jasmine": "^3.4.0",
     "jasmine-spec-reporter": "^4.2.1",
-    "protractor": "6.0.0-beta",
-    "selenium-webdriver": "^4.0.0-alpha.1"
+    "protractor": "6.0.0"
   }
 }


### PR DESCRIPTION
@wswebcreation saw your comment on the last merge/pr. That was the only way I could get it to work, but in this branch I reverted back to the example we discussed. The build fails and this is the result I get everytime I run a protractor test:

```
  W/driverProviders - Using driver provider hosted, but also found extra driver provider parameter(s): sauceUser, sauceKey
[chrome #01] [22:44:29] I/hosted - Using the selenium server at https://ondemand.saucelabs.com/wd/hub
[chrome #01] [22:44:29] E/runner - Unable to start a WebDriver session.
[chrome #01] [22:44:29] I/runnerCli - Misconfigured -- Sauce Labs Authentication Error.
[chrome #01] You used username 'None' and access key 'None' to authenticate, which are not valid Sauce Labs credentials.
[chrome #01] 
[chrome #01] The following desired capabilities were received:
[chrome #01] {'browserName': 'chrome',
[chrome #01]  'browserVersion': 'latest',
[chrome #01]  'chromeOptions': {'w3c': True},
[chrome #01]  'count': 1,
[chrome #01]  'maxInstances': 25,
[chrome #01]  'platformName': 'Windows 10',
[chrome #01]  'sauce:options': {'build': 'Sample Protractor Tests',
[chrome #01]                    'name': 'chrome-protractor-test',
[chrome #01]                    'seleniumVersion': '3.141.59'},
[chrome #01]  'shardTestFiles': True}
```

I'm currently using:
```
"jasmine": "^3.4.0",
"jasmine-spec-reporter": "^4.2.1",
"protractor": "^5.4.2",
"selenium-webdriver": "^4.0.0-alpha.1",
```