### PR TITLE
[Fix] Updating to a browser and platform supported by screener e2e

### DIFF
--- a/screener-e2e/examples/test/configs/wdio.screener.saucelabs.conf.js
+++ b/screener-e2e/examples/test/configs/wdio.screener.saucelabs.conf.js
@@ -19,8 +19,8 @@ config.capabilities = [
      * Desktop browsers
      */
     {
-        browserName: 'googlechrome',
-        platformName: 'Windows 10',
+        browserName: 'chrome',
+        platformName: 'macOS 10.15',
         browserVersion: 'latest',
         'sauce:options': {
             username: config.user,


### PR DESCRIPTION
Changed default platform, screener e2e only supports mac higher than sierra, and browserName has to be chrome