### PR TITLE
fix: update deps

### DIFF
--- a/webdriverio/appium-web/best-practices/babel.config.js
+++ b/webdriverio/appium-web/best-practices/babel.config.js
@@ -1,10 +1,13 @@
 module.exports = {
-    presets: [
-        ['@babel/preset-env', {
-            targets: {
-                node: 12
-            }
-        }]
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: '14',
+        },
+      },
     ],
-    plugins: ['@babel/plugin-proposal-private-methods']
-}
+  ],
+  plugins: ['@babel/plugin-proposal-private-methods'],
+};

--- a/webdriverio/appium-web/best-practices/package-lock.json
+++ b/webdriverio/appium-web/best-practices/package-lock.json
@@ -1170,9 +1170,9 @@
       }
     },
     "@jest/expect-utils": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.0.tgz",
-      "integrity": "sha512-5BrG48dpC0sB80wpeIX5FU6kolDJI4K0n5BM9a5V38MGx0pyRvUBSS0u2aNTdDzmOrCjhOg8pGs6a20ivYkdmw==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.1.tgz",
+      "integrity": "sha512-n/ghlvdhCdMI/hTcnn4qV57kQuV9OTsZzH1TTCVARANKhl6hXJqLKUkwX69ftMGpsbpt96SsDD8n8LD2d9+FRw==",
       "dev": true,
       "requires": {
         "jest-get-type": "^28.0.2"
@@ -1188,9 +1188,9 @@
       }
     },
     "@jest/types": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.0.tgz",
-      "integrity": "sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.1.tgz",
+      "integrity": "sha512-vRXVqSg1VhDnB8bWcmvLzmg0Bt9CRKVgHPXqYwvWMX3TvAjeO+nRuK6+VdTKCtWOvYlmkF/HqNAL/z+N3B53Kw==",
       "dev": true,
       "requires": {
         "@jest/schemas": "^28.0.2",
@@ -1297,32 +1297,6 @@
       "dev": true,
       "optional": true
     },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      }
-    },
     "@sinclair/typebox": {
       "version": "0.23.5",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.5.tgz",
@@ -1343,12 +1317,6 @@
       "requires": {
         "defer-to-connect": "^2.0.0"
       }
-    },
-    "@testim/chrome-version": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.2.tgz",
-      "integrity": "sha512-1c4ZOETSRpI0iBfIFUqU4KqwBAB2lHUAlBjZz/YqOHqwM9dTTzjV6Km0ZkiEiSCx/tLr1BtESIKyWWMww+RUqw==",
-      "dev": true
     },
     "@types/aria-query": {
       "version": "5.0.0",
@@ -1490,9 +1458,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
-      "integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
+      "version": "17.0.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
+      "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ==",
       "dev": true
     },
     "@types/object-inspect": {
@@ -1593,9 +1561,9 @@
       }
     },
     "@wdio/cli": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-7.19.7.tgz",
-      "integrity": "sha512-BxAL2iHBZ/3J5hP48kRWfL6zI7T/WKtybsvQtuDSwYzpgJq6ZrCS8bbOldH6Nvb3YRaP7MmItRQFG7bQwFzJew==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-7.20.2.tgz",
+      "integrity": "sha512-HgT3V8INy7Xe8ZdM7ZnMSAlsy19Mh9P7dmUwONWb2jPf2FNQAF75T5GVj4lQFwBaGP8TKhScYB5sU6phUDXnng==",
       "dev": true,
       "requires": {
         "@types/ejs": "^3.0.5",
@@ -1606,10 +1574,10 @@
         "@types/lodash.union": "^4.6.6",
         "@types/node": "^17.0.4",
         "@types/recursive-readdir": "^2.2.0",
-        "@wdio/config": "7.19.5",
+        "@wdio/config": "7.20.1",
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.19.5",
-        "@wdio/utils": "7.19.7",
+        "@wdio/types": "7.20.0",
+        "@wdio/utils": "7.20.0",
         "async-exit-hook": "^2.0.1",
         "chalk": "^4.0.0",
         "chokidar": "^3.0.0",
@@ -1622,7 +1590,7 @@
         "lodash.union": "^4.6.0",
         "mkdirp": "^1.0.4",
         "recursive-readdir": "^2.2.2",
-        "webdriverio": "7.19.7",
+        "webdriverio": "7.20.2",
         "yargs": "^17.0.0",
         "yarn-install": "^1.0.0"
       },
@@ -1679,43 +1647,77 @@
       }
     },
     "@wdio/config": {
-      "version": "7.19.5",
-      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.19.5.tgz",
-      "integrity": "sha512-GyG0SSUjw9RyDgEwculgwiWyQ0eEeFAgaKTAa4RHC6ZgHHTgfyxzkWqBmNLzHfiB6GSR2DyZDcDsPT7ZAHkiEg==",
+      "version": "7.20.1",
+      "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.20.1.tgz",
+      "integrity": "sha512-5r6ZlvXZLf0wp29FgZChfwcI5zqTBO0xQ8DL/WRk66/bXAdvek+tEaEN7C1cT92czy45Tj9Y64ukozK7YEEjUw==",
       "dev": true,
       "requires": {
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.19.5",
+        "@wdio/types": "7.20.0",
+        "@wdio/utils": "7.20.0",
         "deepmerge": "^4.0.0",
-        "glob": "^7.1.2"
+        "glob": "^8.0.3"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "glob": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
+          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
+          "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
       }
     },
     "@wdio/jasmine-framework": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/jasmine-framework/-/jasmine-framework-7.19.7.tgz",
-      "integrity": "sha512-k/8bxFeO4PadANTCkIVh9iFIiNWjqAYoth0TDgyvHx5kg8areG9I9XQY10D6EDzoyVaEaycj4R5uW820n6Zxgg==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@wdio/jasmine-framework/-/jasmine-framework-7.20.0.tgz",
+      "integrity": "sha512-WcxTecC5piz4whN1o4rHgjgEdXH6op4sWO/umYwKiKaXV6K3guvcoAXjveJRSVxjfxQSTtNYjy1F2SXfZ+A2Ag==",
       "dev": true,
       "requires": {
         "@types/jasmine": "3.10.3",
         "@types/node": "^17.0.4",
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.19.5",
-        "@wdio/utils": "7.19.7",
+        "@wdio/types": "7.20.0",
+        "@wdio/utils": "7.20.0",
         "expect-webdriverio": "^3.0.0",
         "jasmine": "3.10.0"
       }
     },
     "@wdio/local-runner": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-7.19.7.tgz",
-      "integrity": "sha512-DZPaAzUwYZKO1OpBIeGppbY1vP9LJ1N/YT2/FkBy0mvSJ4NbJHj0jbKNUrGpEzOMIklbYPV/htxy3l29pjOkDg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@wdio/local-runner/-/local-runner-7.20.2.tgz",
+      "integrity": "sha512-YP1hziQNtBYkSg7P2OxPk8YKq8/d891wkXWebRPj3fPcNs+uYMV3kSOuPk07jp57EnYdtlljc17U1S7Dp3l3jQ==",
       "dev": true,
       "requires": {
         "@types/stream-buffers": "^3.0.3",
         "@wdio/logger": "7.19.0",
-        "@wdio/repl": "7.19.7",
-        "@wdio/runner": "7.19.7",
-        "@wdio/types": "7.19.5",
+        "@wdio/repl": "7.20.0",
+        "@wdio/runner": "7.20.2",
+        "@wdio/types": "7.20.0",
         "async-exit-hook": "^2.0.1",
         "split2": "^4.0.0",
         "stream-buffers": "^3.0.2"
@@ -1785,24 +1787,24 @@
       }
     },
     "@wdio/protocols": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.19.0.tgz",
-      "integrity": "sha512-ji74rQag6v+INSNd0J8eAh2rpH5vOXgeiP5Qr32K6PWU6HzYWuAFH2x4srXsH0JawHCdTK2OQAOYrLmMb44hug==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.20.2.tgz",
+      "integrity": "sha512-xILO7Yl96zB3n9eZ5UlBeJWBScqHyWix9k/DSzau5XmOOlrtFXppziKzuvPqbA4BzEpqfIe0KbuWJh0XYtkX6w==",
       "dev": true
     },
     "@wdio/repl": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.19.7.tgz",
-      "integrity": "sha512-6lgzZxSU2yV0YLb4byBASeC42y5rAZk7mOQ41fHTXyC9CfRJubwe47M9KJyAoOrHG2wpwUX92RLTpDrAVDV6Fg==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@wdio/repl/-/repl-7.20.0.tgz",
+      "integrity": "sha512-rb22rzBNo6AnV3gVYDTt65vi59RW3Zohhmuoe+vsAwz06ryeKTau95Zaz5x55Z1OjHqWvEHRAHmTkI3p0Zdw0g==",
       "dev": true,
       "requires": {
-        "@wdio/utils": "7.19.7"
+        "@wdio/utils": "7.20.0"
       }
     },
     "@wdio/reporter": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-7.19.7.tgz",
-      "integrity": "sha512-Dum19gpfru66FnIq78/4HTuW87B7ceLDp6PJXwQM5kXyN7Gb7zhMgp6FZTM0FCYLyi6U/zXZSvpNUYl77caS6g==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@wdio/reporter/-/reporter-7.20.0.tgz",
+      "integrity": "sha512-QPHaFH9X7dPP5WguRJJY2jDuBPoX+ZSvsDCI9CDOCDvg6ZgrY1Kb0R++U1YJ4swNQYppOYDdgAZTHlaa7/VG9w==",
       "dev": true,
       "requires": {
         "@types/diff": "^5.0.0",
@@ -1810,7 +1812,7 @@
         "@types/object-inspect": "^1.8.0",
         "@types/supports-color": "^8.1.0",
         "@types/tmp": "^0.2.0",
-        "@wdio/types": "7.19.5",
+        "@wdio/types": "7.20.0",
         "diff": "^5.0.0",
         "fs-extra": "^10.0.0",
         "object-inspect": "^1.10.3",
@@ -1835,44 +1837,44 @@
       }
     },
     "@wdio/runner": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-7.19.7.tgz",
-      "integrity": "sha512-PH4vOMwPnAU+cOTPrkJrU20CDDFGccBf4VV80GAQK9b71pfD+T7MIvUCnL0x/kMgIQV/0rFtM+6y5CDZI0R27g==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-7.20.2.tgz",
+      "integrity": "sha512-ZG2SV2ngYIXSX5siVePkUV26ZeZGBwPeoJ4WZCKStEpSwYHfzDi8tQVzUtBmtUJww3GJFBlzePTx8KpkkWqKWQ==",
       "dev": true,
       "requires": {
-        "@wdio/config": "7.19.5",
+        "@wdio/config": "7.20.1",
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.19.5",
-        "@wdio/utils": "7.19.7",
+        "@wdio/types": "7.20.0",
+        "@wdio/utils": "7.20.0",
         "deepmerge": "^4.0.0",
         "gaze": "^1.1.2",
-        "webdriver": "7.19.7",
-        "webdriverio": "7.19.7"
+        "webdriver": "7.20.2",
+        "webdriverio": "7.20.2"
       }
     },
     "@wdio/sauce-service": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/sauce-service/-/sauce-service-7.19.7.tgz",
-      "integrity": "sha512-1ZMXmMVCFRWNbWheK7O2sje6XXS3INJ0rmgy8W0YSj0LK+3qSciT+HPivZd1WbRz2JQmNToT6tPkWBlzNqg+4Q==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@wdio/sauce-service/-/sauce-service-7.20.2.tgz",
+      "integrity": "sha512-8febPY4mKsildIGvrivVQ/Zp+7SGmJeGV1zkMekys9Rv5/V7RekvQ5KFy3cLtyd4fwZnT56x+eCdGkVkU2ylCg==",
       "dev": true,
       "requires": {
         "@types/node": "^17.0.4",
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.19.5",
-        "@wdio/utils": "7.19.7",
+        "@wdio/types": "7.20.0",
+        "@wdio/utils": "7.20.0",
         "saucelabs": "^7.1.3",
-        "webdriverio": "7.19.7"
+        "webdriverio": "7.20.2"
       }
     },
     "@wdio/spec-reporter": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-7.19.7.tgz",
-      "integrity": "sha512-BDBZU2EK/GuC9VxtfqPtoW43FmvKxYDsvcDVDi3F7o+9fkcuGSJiWbw1AX251ZzzVQ7YP9ImTitSpdpUKXkilQ==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@wdio/spec-reporter/-/spec-reporter-7.20.0.tgz",
+      "integrity": "sha512-DqXS4zPihl0nJbT4S28FIkvGWxgkmfrLlyQjUO0yraUu9bslUto/Bs3dQzTG8QvIDoFBP5rl5bkcXcOwVnxfnw==",
       "dev": true,
       "requires": {
         "@types/easy-table": "^0.0.33",
-        "@wdio/reporter": "7.19.7",
-        "@wdio/types": "7.19.5",
+        "@wdio/reporter": "7.20.0",
+        "@wdio/types": "7.20.0",
         "chalk": "^4.0.0",
         "easy-table": "^1.1.1",
         "pretty-ms": "^7.0.0"
@@ -1930,9 +1932,9 @@
       }
     },
     "@wdio/types": {
-      "version": "7.19.5",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.19.5.tgz",
-      "integrity": "sha512-S1lC0pmtEO7NVH/2nM1c7NHbkgxLZH3VVG/z6ym3Bbxdtcqi2LMsEvvawMAU/fmhyiIkMsGZCO8vxG9cRw4z4A==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.20.0.tgz",
+      "integrity": "sha512-iYQAlkPxDIt2iJI4KwYmdenAU6XC+c68J8lkBVtmkY9S6nSXbQtrzNZoWw03j0//dbagVa6cdefrnhnkxDr0Hg==",
       "dev": true,
       "requires": {
         "@types/node": "^17.0.4",
@@ -1940,13 +1942,13 @@
       }
     },
     "@wdio/utils": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.19.7.tgz",
-      "integrity": "sha512-i/fBnEmEGDQ8Sr8H8p9UZ0kUPjSQhoJE2EullSyX+YgyZDtO3JO0M0jiRpbCFr0M+7fi17g+YOzQWmCSRGhPJA==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.20.0.tgz",
+      "integrity": "sha512-3LSNbXcubGpIEuhnUBDChXHiFldypIxzDAApTb6RGaEFbzrBJ3dD7vb90hHkZ/DEfuxRihLE/V4Cw2oH+pcVBQ==",
       "dev": true,
       "requires": {
         "@wdio/logger": "7.19.0",
-        "@wdio/types": "7.19.5",
+        "@wdio/types": "7.20.0",
         "p-iteration": "^1.1.8"
       }
     },
@@ -1957,24 +1959,6 @@
       "dev": true,
       "requires": {
         "debug": "4"
-      }
-    },
-    "aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "dependencies": {
-        "indent-string": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "dev": true
-        }
       }
     },
     "ansi-escapes": {
@@ -2093,16 +2077,10 @@
       "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
       "dev": true
     },
-    "array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true
-    },
     "async": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
     },
     "async-exit-hook": {
@@ -2116,21 +2094,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
-    },
-    "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "^1.14.4"
-      }
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
@@ -2228,15 +2191,15 @@
       }
     },
     "browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.4.tgz",
+      "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
+        "caniuse-lite": "^1.0.30001349",
+        "electron-to-chromium": "^1.4.147",
         "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
+        "node-releases": "^2.0.5",
         "picocolors": "^1.0.0"
       }
     },
@@ -2327,7 +2290,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -2336,7 +2299,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
           "dev": true
         }
       }
@@ -2399,9 +2362,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001344",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
-      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
+      "version": "1.0.30001352",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
+      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==",
       "dev": true
     },
     "capital-case": {
@@ -2475,9 +2438,9 @@
       "dev": true
     },
     "chrome-launcher": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.0.tgz",
-      "integrity": "sha512-ZQqX5kb9H0+jy1OqLnWampfocrtSZaGl7Ny3F9GRha85o4odbL8x55paUzh51UC7cEmZ5obp3H2Mm70uC2PpRA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz",
+      "integrity": "sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -2494,31 +2457,10 @@
         }
       }
     },
-    "chromedriver": {
-      "version": "101.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-101.0.0.tgz",
-      "integrity": "sha512-LkkWxy6KM/0YdJS8qBeg5vfkTZTRamhBfOttb4oic4echDgWvCU1E8QcBbUBOHqZpSrYMyi7WMKmKMhXFUaZ+w==",
-      "dev": true,
-      "requires": {
-        "@testim/chrome-version": "^1.1.2",
-        "axios": "^0.24.0",
-        "del": "^6.0.0",
-        "extract-zip": "^2.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "proxy-from-env": "^1.1.0",
-        "tcp-port-used": "^1.0.1"
-      }
-    },
     "ci-info": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
       "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
-      "dev": true
-    },
-    "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
     "cli-cursor": {
@@ -2681,9 +2623,9 @@
       }
     },
     "core-js-compat": {
-      "version": "3.22.7",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.7.tgz",
-      "integrity": "sha512-uI9DAQKKiiE/mclIC5g4AjRpio27g+VMRhe6rQoz+q4Wm4L6A/fJhiLtBw+sfOpDG9wZ3O0pxIw7GbfOlBgjOA==",
+      "version": "3.22.8",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.8.tgz",
+      "integrity": "sha512-pQnwg4xtuvc2Bs/5zYQPaEYYSuTxsF7LBWF0SvnVhthZo/Qe+rJpcEekrdNK5DWwDJ0gv0oI9NNX5Mppdy0ctg==",
       "dev": true,
       "requires": {
         "browserslist": "^4.20.3",
@@ -2805,7 +2747,7 @@
             "pify": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
               "dev": true
             }
           }
@@ -2813,7 +2755,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
       }
@@ -2974,16 +2916,10 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
       }
-    },
-    "deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
     },
     "deepmerge": {
       "version": "4.2.2",
@@ -3016,30 +2952,6 @@
         "object-keys": "^1.1.1"
       }
     },
-    "del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "dev": true,
-      "requires": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
-      }
-    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3047,18 +2959,18 @@
       "dev": true
     },
     "devtools": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.19.7.tgz",
-      "integrity": "sha512-XkIuojwTD0LeCzEeoTozKfAYWZUAw5Sj6CNPUuift3eDD9wnY2AcKLmFw8e9ihVUevJriyV8tMNbDsl97HSYWg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/devtools/-/devtools-7.20.2.tgz",
+      "integrity": "sha512-FeXQc/IeoHhGI0gsua1xXOZDHPflGtAoTiBoGXTfLQzZVIVUA7lY2UxLI382H5cVI9iwf44zm5fNaZh3y0NOTw==",
       "dev": true,
       "requires": {
         "@types/node": "^17.0.4",
         "@types/ua-parser-js": "^0.7.33",
-        "@wdio/config": "7.19.5",
+        "@wdio/config": "7.20.1",
         "@wdio/logger": "7.19.0",
-        "@wdio/protocols": "7.19.0",
-        "@wdio/types": "7.19.5",
-        "@wdio/utils": "7.19.7",
+        "@wdio/protocols": "7.20.2",
+        "@wdio/types": "7.20.0",
+        "@wdio/utils": "7.20.0",
         "chrome-launcher": "^0.15.0",
         "edge-paths": "^2.1.0",
         "puppeteer-core": "^13.1.3",
@@ -3068,9 +2980,9 @@
       }
     },
     "devtools-protocol": {
-      "version": "0.0.998712",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.998712.tgz",
-      "integrity": "sha512-KCl+wJ9RsnDyGSsW7nbkgLFYxcKxZ7nzr6/r/hMOjkS02q2x1p8PbUenzKRMfL0jALhYxkCHrYnPnV3GHVD9EQ==",
+      "version": "0.0.1010518",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1010518.tgz",
+      "integrity": "sha512-/BRxPyaNqkFj0YzExbAkJ+edGYTuWiilDRPWxVU3oSivNIJKuXk4Uj2LB4BV14I44FNiCYyYZizJOjfUIq+rLQ==",
       "dev": true
     },
     "diff": {
@@ -3080,27 +2992,10 @@
       "dev": true
     },
     "diff-sequences": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.0.2.tgz",
-      "integrity": "sha512-YtEoNynLDFCRznv/XDalsKGSZDoj0U5kLnXvY0JSq3nBboRrZXjD81+eSiwi+nzcZDwedMmcowcxNwwgFW23mQ==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
       "dev": true
-    },
-    "dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "requires": {
-        "path-type": "^4.0.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-          "dev": true
-        }
-      }
     },
     "dot-case": {
       "version": "3.0.4",
@@ -3161,7 +3056,7 @@
             "lowercase-keys": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+              "integrity": "sha512-RPlX0+PHuvxVDZ7xX+EBVAp4RsVxP/TdDSN2mJYdiq1Lc4Hz7EUSjUI7RZrKKlmrIzVhf6Jo2stj7++gVarS0A==",
               "dev": true
             }
           }
@@ -3218,7 +3113,7 @@
             "pify": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
               "dev": true
             }
           }
@@ -3270,7 +3165,7 @@
         "responselike": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-          "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+          "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
           "dev": true,
           "requires": {
             "lowercase-keys": "^1.0.0"
@@ -3279,7 +3174,7 @@
         "sort-keys": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-          "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+          "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
           "dev": true,
           "requires": {
             "is-plain-obj": "^1.0.0"
@@ -3323,9 +3218,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.141",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.141.tgz",
-      "integrity": "sha512-mfBcbqc0qc6RlxrsIgLG2wCqkiPAjEezHxGTu7p3dHHFOurH4EjS9rFZndX5axC8264rI1Pcbw8uQP39oZckeA==",
+      "version": "1.4.152",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.152.tgz",
+      "integrity": "sha512-jk4Ju5SGZAQQJ1iI4Rgru7dDlvkQPLpNPWH9gIZmwCD4YteA5Bbk1xPcPDUf5jUYs3e1e80RXdi8XgKQZaigeg==",
       "dev": true
     },
     "emoji-regex": {
@@ -3371,16 +3266,16 @@
       "dev": true
     },
     "expect": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.0.tgz",
-      "integrity": "sha512-qFXKl8Pmxk8TBGfaFKRtcQjfXEnKAs+dmlxdwvukJZorwrAabT7M3h8oLOG01I2utEhkmUTi17CHaPBovZsKdw==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.1.tgz",
+      "integrity": "sha512-/AANEwGL0tWBwzLNOvO0yUdy2D52jVdNXppOqswC49sxMN2cPWsGCQdzuIf9tj6hHoBQzNvx75JUYuQAckPo3w==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^28.1.0",
+        "@jest/expect-utils": "^28.1.1",
         "jest-get-type": "^28.0.2",
-        "jest-matcher-utils": "^28.1.0",
-        "jest-message-util": "^28.1.0",
-        "jest-util": "^28.1.0"
+        "jest-matcher-utils": "^28.1.1",
+        "jest-message-util": "^28.1.1",
+        "jest-util": "^28.1.1"
       }
     },
     "expect-webdriverio": {
@@ -3440,28 +3335,6 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
       "dev": true
-    },
-    "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
-      "dev": true,
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      }
-    },
-    "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
-      "dev": true,
-      "requires": {
-        "reusify": "^1.0.4"
-      }
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -3561,12 +3434,6 @@
       "requires": {
         "locate-path": "^3.0.0"
       }
-    },
-    "follow-redirects": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
-      "dev": true
     },
     "form-data": {
       "version": "4.0.0",
@@ -3679,14 +3546,14 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
+      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-stream": {
@@ -3726,28 +3593,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
-    },
-    "globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-      "dev": true,
-      "requires": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-          "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-          "dev": true
-        }
-      }
     },
     "globule": {
       "version": "1.3.3",
@@ -3945,12 +3790,6 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
-    "ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-      "dev": true
-    },
     "indent-string": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
@@ -4057,12 +3896,6 @@
         "p-is-promise": "^1.1.0"
       }
     },
-    "ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "dev": true
-    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4138,18 +3971,6 @@
       "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
       "dev": true
     },
-    "is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "dev": true
-    },
-    "is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true
-    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -4183,12 +4004,6 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
-    "is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true
-    },
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -4202,17 +4017,6 @@
       "dev": true,
       "requires": {
         "is-docker": "^2.0.0"
-      }
-    },
-    "is2": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.7.tgz",
-      "integrity": "sha512-4vBQoURAXC6hnLFxD4VW7uc04XiwTTl/8ydYJxKvPwkWQrSjInkuM5VZVg6BGr1/natq69zDuvO9lGpLClJqvA==",
-      "dev": true,
-      "requires": {
-        "deep-is": "^0.1.3",
-        "ip-regex": "^4.1.0",
-        "is-url": "^1.2.4"
       }
     },
     "isarray": {
@@ -4323,15 +4127,15 @@
       "dev": true
     },
     "jest-diff": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.0.tgz",
-      "integrity": "sha512-8eFd3U3OkIKRtlasXfiAQfbovgFgRDb0Ngcs2E+FMeBZ4rUezqIaGjuyggJBp+llosQXNEWofk/Sz4Hr5gMUhA==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.1.tgz",
+      "integrity": "sha512-/MUUxeR2fHbqHoMMiffe/Afm+U8U4olFRJ0hiVG2lZatPJcnGxx292ustVu7bULhjV65IYMxRdploAKLbcrsyg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^28.0.2",
+        "diff-sequences": "^28.1.1",
         "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.0"
+        "pretty-format": "^28.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4392,15 +4196,15 @@
       "dev": true
     },
     "jest-matcher-utils": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.0.tgz",
-      "integrity": "sha512-onnax0n2uTLRQFKAjC7TuaxibrPSvZgKTcSCnNUz/tOjJ9UhxNm7ZmPpoQavmTDUjXvUQ8KesWk2/VdrxIFzTQ==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.1.tgz",
+      "integrity": "sha512-NPJPRWrbmR2nAJ+1nmnfcKKzSwgfaciCCrYZzVnNoxVoyusYWIjkBMNvu0RHJe7dNj4hH3uZOPZsQA+xAYWqsw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^28.1.0",
+        "jest-diff": "^28.1.1",
         "jest-get-type": "^28.0.2",
-        "pretty-format": "^28.1.0"
+        "pretty-format": "^28.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4455,18 +4259,18 @@
       }
     },
     "jest-message-util": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.0.tgz",
-      "integrity": "sha512-RpA8mpaJ/B2HphDMiDlrAZdDytkmwFqgjDZovM21F35lHGeUeCvYmm6W+sbQ0ydaLpg5bFAUuWG1cjqOl8vqrw==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.1.tgz",
+      "integrity": "sha512-xoDOOT66fLfmTRiqkoLIU7v42mal/SqwDKvfmfiWAdJMSJiU+ozgluO7KbvoAgiwIrrGZsV7viETjc8GNrA/IQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^28.1.0",
+        "@jest/types": "^28.1.1",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^28.1.0",
+        "pretty-format": "^28.1.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -4529,12 +4333,12 @@
       }
     },
     "jest-util": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.0.tgz",
-      "integrity": "sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.1.tgz",
+      "integrity": "sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==",
       "dev": true,
       "requires": {
-        "@jest/types": "^28.1.0",
+        "@jest/types": "^28.1.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -4706,7 +4510,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -4714,7 +4518,7 @@
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "integrity": "sha512-cy7ZdNRXdablkXYNI049pthVeXFurRyb9+hA/dZzerZ0pGTx42z+y+ssxBaVV2l70t1muq5IdKhn4UtcoGUY9A==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -4727,7 +4531,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
       }
@@ -4751,49 +4555,49 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
     "lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
       "dev": true
     },
     "lodash.difference": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
       "dev": true
     },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "lodash.isobject": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=",
+      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA==",
       "dev": true
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
       "dev": true
     },
     "lodash.merge": {
@@ -4805,19 +4609,19 @@
     "lodash.pickby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
       "dev": true
     },
     "lodash.union": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
     "lodash.zip": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.zip/-/lodash.zip-4.2.0.tgz",
-      "integrity": "sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=",
+      "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
       "dev": true
     },
     "log-symbols": {
@@ -4931,19 +4735,13 @@
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
       "dev": true
     },
     "marky": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.4.tgz",
       "integrity": "sha512-zd2/GiSn6U3/jeFVZ0J9CA1LzQ8RfIVvXkb/U0swFHF/zT+dVohTAWjmo2DcIuofmIIIROlwTbd+shSeXmxr0w==",
-      "dev": true
-    },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "micromatch": {
@@ -5080,7 +4878,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true
     },
     "object-inspect": {
@@ -5196,7 +4994,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
     "p-cancelable": {
@@ -5217,13 +5015,13 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "dev": true
     },
     "p-is-promise": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "integrity": "sha512-zL7VE4JVS2IFSkR2GQKDSPEVxkoH43/p7oEnwpdCndKYJO0HVeRB7fA8TJwuLOTBREtK0ea8eHaxdwcpob5dmg==",
       "dev": true
     },
     "p-iteration": {
@@ -5248,15 +5046,6 @@
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
-      }
-    },
-    "p-map": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "dev": true,
-      "requires": {
-        "aggregate-error": "^3.0.0"
       }
     },
     "p-timeout": {
@@ -5287,7 +5076,7 @@
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
@@ -5322,7 +5111,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true
     },
     "path-is-absolute": {
@@ -5340,7 +5129,7 @@
     "path-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "integrity": "sha512-S4eENJz1pkiQn9Znv33Q+deTOKmbl+jj1Fl+qiP/vYezj+S8x+J3Uo0ISrx/QoEvIlOaDWJhPaRd1flJ9HXZqg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5351,7 +5140,7 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
       }
@@ -5359,7 +5148,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
     "picocolors": {
@@ -5383,13 +5172,13 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
       "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
@@ -5413,13 +5202,13 @@
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
       "dev": true
     },
     "pretty-format": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.0.tgz",
-      "integrity": "sha512-79Z4wWOYCdvQkEoEuSlBhHJqWeZ8D8YRPiPctJFCtvuaClGpiwiQYSCUOE6IEKUbbFukKOTFIUAXE8N4EQTo1Q==",
+      "version": "28.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.1.tgz",
+      "integrity": "sha512-wwJbVTGFHeucr5Jw2bQ9P+VYHyLdAqedFLEkdQUVaBF/eiidDwH5OpilINq4mEfhbCjLnirt6HTTDhv1HaTIQw==",
       "dev": true,
       "requires": {
         "@jest/schemas": "^28.0.2",
@@ -5466,7 +5255,7 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
     "pump": {
@@ -5567,12 +5356,6 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
-    },
     "quick-lru": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
@@ -5588,7 +5371,7 @@
     "read-pkg": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "integrity": "sha512-7BGwRHqt4s/uVbuyoeejRn4YmFnYZiFl4AuaeXHlgZf3sONF0SOGlxs2Pw8g6hCKupo08RafIO5YXFNOKTfwsQ==",
       "dev": true,
       "requires": {
         "load-json-file": "^1.0.0",
@@ -5599,7 +5382,7 @@
     "read-pkg-up": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "integrity": "sha512-WD9MTlNtI55IwYUS27iHh9tK3YoIVhxis8yKhLpTqWtml739uXc9NWTpxoHkfZf3+DkCCsXox94/VWZniuZm6A==",
       "dev": true,
       "requires": {
         "find-up": "^1.0.0",
@@ -5619,7 +5402,7 @@
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "integrity": "sha512-yTltuKuhtNeFJKa1PiRzfLAU5182q1y4Eb4XCJ3PBqyzEDkAZRzBrKKBct682ls9reBVHf9udYLN5Nd+K1B9BQ==",
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -5746,7 +5529,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "resolve": {
@@ -5794,12 +5577,6 @@
         "signal-exit": "^3.0.2"
       }
     },
-    "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true
-    },
     "rgb2hex": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/rgb2hex/-/rgb2hex-0.2.5.tgz",
@@ -5820,15 +5597,6 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
     },
     "rxjs": {
       "version": "7.5.5",
@@ -5951,7 +5719,7 @@
     "sort-keys": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
       "dev": true,
       "requires": {
         "is-plain-obj": "^1.0.0"
@@ -5960,7 +5728,7 @@
     "sort-keys-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
-      "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+      "integrity": "sha512-GRbEOUqCxemTAk/b32F2xa8wDTs+Z1QHOkbhJDQTvv/6G3ZkbJ+frYWsTcc7cBB3Fu4wy4XlLCuNtJuMn7Gsvw==",
       "dev": true,
       "requires": {
         "sort-keys": "^1.0.0"
@@ -6046,7 +5814,7 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ==",
       "dev": true
     },
     "string-width": {
@@ -6089,7 +5857,7 @@
     "strip-bom": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "integrity": "sha512-kwrX1y7czp1E69n2ajbG65mIo9dqvJ+8aBQXOGVxqwvNbsXdFM6Lq37dLAY3mknUwru8CfcCbfOLL/gMo+fi3g==",
       "dev": true,
       "requires": {
         "is-utf8": "^0.2.0"
@@ -6116,7 +5884,7 @@
     "suffix": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/suffix/-/suffix-0.1.1.tgz",
-      "integrity": "sha1-zFgjFkag7xEC95R47zqSSP2chC8=",
+      "integrity": "sha512-j5uf6MJtMCfC4vBe5LFktSe4bGyNTBk7I2Kdri0jeLrcv5B9pWfxVa5JQpoxgtR8vaVB7bVxsWgnfQbX5wkhAA==",
       "dev": true
     },
     "supports-color": {
@@ -6159,43 +5927,22 @@
         "readable-stream": "^3.1.1"
       }
     },
-    "tcp-port-used": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
-      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
-      "dev": true,
-      "requires": {
-        "debug": "4.3.1",
-        "is2": "^2.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
-      }
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
       "dev": true
     },
     "tmp": {
@@ -6231,13 +5978,13 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
     },
     "trim-repeated": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
-      "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.2"
@@ -6332,7 +6079,7 @@
     "url-parse-lax": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
       "dev": true,
       "requires": {
         "prepend-http": "^2.0.0"
@@ -6341,7 +6088,7 @@
     "url-to-options": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "integrity": "sha512-0kQLIzG4fdk/G5NONku64rSH/x32NOA39LVQqlK8Le6lvTF6GGRJpqaQFGgU+CLwySIqBSMdwYM0sYcW9f6P4A==",
       "dev": true
     },
     "util-deprecate": {
@@ -6369,84 +6116,49 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
       }
     },
-    "wdio-chromedriver-service": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/wdio-chromedriver-service/-/wdio-chromedriver-service-7.3.2.tgz",
-      "integrity": "sha512-4M3OqFzBSC4FdbqkfwOrUMeroMEuyIFCHfcUebkU6tJ1w5GenWO61YweJ8NKlhPZx9nkO8223+20MpvBjv+fTg==",
-      "dev": true,
-      "requires": {
-        "@wdio/logger": "^7.5.3",
-        "fs-extra": "^9.1.0",
-        "split2": "^3.2.2",
-        "tcp-port-used": "^1.0.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "split2": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^3.0.0"
-          }
-        }
-      }
-    },
     "webdriver": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.19.7.tgz",
-      "integrity": "sha512-3gygDpwaCMZlUhh7Wv1SbjTvfdLGbPqRQ3poZ7lKvsVAAmciLziJDeR8LrNTyS9R418MgNbBdWOQrHGS+gp0ZQ==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.20.2.tgz",
+      "integrity": "sha512-8RG3pdvfe4aZkKXrULlS1EiMacLQpivaMk8GpE5NnM7A1oGCQjZ7sbQZq81XyQspQhezwmW+rG7DegAnDcMz1Q==",
       "dev": true,
       "requires": {
         "@types/node": "^17.0.4",
-        "@wdio/config": "7.19.5",
+        "@wdio/config": "7.20.1",
         "@wdio/logger": "7.19.0",
-        "@wdio/protocols": "7.19.0",
-        "@wdio/types": "7.19.5",
-        "@wdio/utils": "7.19.7",
+        "@wdio/protocols": "7.20.2",
+        "@wdio/types": "7.20.0",
+        "@wdio/utils": "7.20.0",
         "got": "^11.0.2",
         "ky": "^0.30.0",
         "lodash.merge": "^4.6.1"
       }
     },
     "webdriverio": {
-      "version": "7.19.7",
-      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.19.7.tgz",
-      "integrity": "sha512-GaekRmFN3wokW3VN08hFjTJ3GagJxuKR6AV8kVvlxxMye9nfU3TQPzsrqGrue8uWYvyZ3x0SVkUluwtImZNzPA==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.20.2.tgz",
+      "integrity": "sha512-IaQLmRUHv3OcjL4QJZVKqPS7+KZgH0bVGeHErpDx28zMozbkDBbSdy01xnzaHEZW+OwXNBECaNmqQ3GvtUZKsQ==",
       "dev": true,
       "requires": {
         "@types/aria-query": "^5.0.0",
         "@types/node": "^17.0.4",
-        "@wdio/config": "7.19.5",
+        "@wdio/config": "7.20.1",
         "@wdio/logger": "7.19.0",
-        "@wdio/protocols": "7.19.0",
-        "@wdio/repl": "7.19.7",
-        "@wdio/types": "7.19.5",
-        "@wdio/utils": "7.19.7",
+        "@wdio/protocols": "7.20.2",
+        "@wdio/repl": "7.20.0",
+        "@wdio/types": "7.20.0",
+        "@wdio/utils": "7.20.0",
         "archiver": "^5.0.0",
         "aria-query": "^5.0.0",
         "css-shorthand-properties": "^1.1.1",
         "css-value": "^0.0.1",
-        "devtools": "7.19.7",
-        "devtools-protocol": "^0.0.998712",
+        "devtools": "7.20.2",
+        "devtools-protocol": "^0.0.1010518",
         "fs-extra": "^10.0.0",
         "grapheme-splitter": "^1.0.2",
         "lodash.clonedeep": "^4.5.0",
@@ -6459,7 +6171,7 @@
         "resq": "^1.9.1",
         "rgb2hex": "0.2.5",
         "serialize-error": "^8.0.0",
-        "webdriver": "7.19.7"
+        "webdriver": "7.20.2"
       },
       "dependencies": {
         "brace-expansion": {
@@ -6485,13 +6197,13 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "requires": {
         "tr46": "~0.0.3",
@@ -6571,7 +6283,7 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
     },
     "yargs": {
@@ -6598,7 +6310,7 @@
     "yarn-install": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yarn-install/-/yarn-install-1.0.0.tgz",
-      "integrity": "sha1-V/RQULgu/VcYKzlzxUqgXLXSUjA=",
+      "integrity": "sha512-VO1u181msinhPcGvQTVMnHVOae8zjX/NSksR17e6eXHRveDvHCF5mGjh9hkN8mzyfnCqcBe42LdTs7bScuTaeg==",
       "dev": true,
       "requires": {
         "cac": "^3.0.3",
@@ -6634,7 +6346,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6643,7 +6355,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
           "dev": true
         }
       }
@@ -6651,7 +6363,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/webdriverio/appium-web/best-practices/package.json
+++ b/webdriverio/appium-web/best-practices/package.json
@@ -18,12 +18,10 @@
     "@babel/plugin-proposal-private-methods": "^7.17.12",
     "@babel/preset-env": "^7.18.2",
     "@babel/register": "^7.17.7",
-    "@wdio/cli": "^7.19.7",
-    "@wdio/jasmine-framework": "^7.19.7",
-    "@wdio/local-runner": "^7.19.7",
-    "@wdio/sauce-service": "^7.19.7",
-    "@wdio/spec-reporter": "^7.19.7",
-    "chromedriver": "^101.0.0",
-    "wdio-chromedriver-service": "^7.3.2"
+    "@wdio/cli": "^7.20.2",
+    "@wdio/jasmine-framework": "^7.20.0",
+    "@wdio/local-runner": "^7.20.2",
+    "@wdio/sauce-service": "^7.20.2",
+    "@wdio/spec-reporter": "^7.20.0"
   }
 }

--- a/webdriverio/appium-web/best-practices/test/configs/wdio.saucelabs.android.conf.js
+++ b/webdriverio/appium-web/best-practices/test/configs/wdio.saucelabs.android.conf.js
@@ -13,20 +13,36 @@ const build = `Best Practices: Android Chrome Appium '${
 // https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/
 config.capabilities = ['8.1', '9.0', '10.0', '11.0', '12.0'].map(
   (androidVersion) => ({
-    browserName: 'Chrome',
-    deviceName: 'Android GoogleAPI Emulator',
-    platformName: 'Android',
-    platformVersion: androidVersion,
-    build: build,
+    // All vendor specific, in this case Appium capabilities, should be
+    // put in vendor prefixed options, see
+    // https://www.w3.org/TR/webdriver1/#dfn-extension-capability
+    // All Appium capabilities, see
+    // http://appium.io/docs/en/writing-running-appium/caps/
+    // should be prefixed with `appium:{capability-name}`
+    'appium:platformVersion': androidVersion,
+    'appium:deviceName': 'Android GoogleAPI Emulator',
     // Older versions of Appium give issues with sending keys, see
     // https://github.com/appium/appium/issues/12059
-    appiumVersion: '1.20.2',
+    'appium:appiumVersion': '1.20.2',
+    // For the W3C capabilities, please check
+    // https://www.w3.org/TR/webdriver1/#capabilities
+    browserName: 'Chrome',
+    platformName: 'Android',
+    // All vendor specific, in this case Sauce specific capabilities, should be
+    // put in vendor prefixed options, see
+    // https://www.w3.org/TR/webdriver1/#dfn-extension-capability
+    'sauce:options': {
+      build: build,
+    },
   })
 );
 
-if (config.appiumVersion !== undefined && config.appiumVersion !== 'default') {
+if (
+  config['appium:appiumVersion'] !== undefined &&
+  config['appium:appiumVersion'] !== 'default'
+) {
   config.capabilities.forEach((capability) => {
-    capability.appiumVersion = config.appiumVersion;
+    capability['appium:appiumVersion'] = config['appium:appiumVersion'];
   });
 }
 

--- a/webdriverio/appium-web/best-practices/test/configs/wdio.saucelabs.ios.conf.js
+++ b/webdriverio/appium-web/best-practices/test/configs/wdio.saucelabs.ios.conf.js
@@ -1,5 +1,7 @@
-const {config} = require('./wdio.shared.sauce.mobile.conf');
-const build = `Best Practices: iOS Safari Appium '${config.appiumVersion}' build-${new Date().getTime()}`;
+const { config } = require('./wdio.shared.sauce.mobile.conf');
+const build = `Best Practices: iOS Safari Appium '${
+  config.appiumVersion
+}' build-${new Date().getTime()}`;
 
 // ============
 // Capabilities
@@ -9,20 +11,34 @@ const build = `Best Practices: iOS Safari Appium '${config.appiumVersion}' build
 //
 // For configuring a Simulator please check
 // https://wiki.saucelabs.com/display/DOCS/Platform+Configurator#/
-config.capabilities = ['13.4', '14.0', '14.3'].map(iOSVersion =>(
-  {
-      build: build,
-      browserName: 'safari',
-      platformName: 'iOS',
-      platformVersion: iOSVersion,
-      deviceName: 'iPhone Simulator',
-  }
-));
+config.capabilities = ['13.4', '14.5', '15.4'].map((iOSVersion) => ({
+  // All vendor specific, in this case Appium capabilities, should be
+  // put in vendor prefixed options, see
+  // https://www.w3.org/TR/webdriver1/#dfn-extension-capability
+  // All Appium capabilities, see
+  // http://appium.io/docs/en/writing-running-appium/caps/
+  // should be prefixed with `appium:{capability-name}`
+  'appium:platformVersion': iOSVersion,
+  'appium:deviceName': 'iPhone Simulator',
+  // For the W3C capabilities, please check
+  // https://www.w3.org/TR/webdriver1/#capabilities
+  browserName: 'safari',
+  platformName: 'iOS',
+  // All vendor specific, in this case Sauce specific capabilities, should be
+  // put in vendor prefixed options, see
+  // https://www.w3.org/TR/webdriver1/#dfn-extension-capability
+  'sauce:options': {
+    build: build,
+  },
+}));
 
-if (config.appiumVersion !== undefined && config.appiumVersion !== 'default') {
-    config.capabilities.forEach(capability => {
-        capability.appiumVersion = config.appiumVersion;
-    });
+if (
+  config['appium:appiumVersion'] !== undefined &&
+  config['appium:appiumVersion'] !== 'default'
+) {
+  config.capabilities.forEach((capability) => {
+    capability['appium:appiumVersion'] = config['appium:appiumVersion'];
+  });
 }
 
 exports.config = config;

--- a/webdriverio/appium-web/best-practices/test/configs/wdio.shared.conf.js
+++ b/webdriverio/appium-web/best-practices/test/configs/wdio.shared.conf.js
@@ -26,6 +26,8 @@ exports.config = {
   reporters: ['spec'],
   jasmineOpts: {
     defaultTimeoutInterval: 60000,
+    // Babel setup
+    helpers: [require.resolve('@babel/register')],
   },
   services: [],
 };


### PR DESCRIPTION
this PR contains the following:

- update Appium Web BP to latest WDIO deps
- removes not needed deps
- changes the protocol from JWP to W3C which fixes an issue with Appium and iOS where Appium returned the `:wdc:` atom-id which broke the execution