### PR TITLE
Upgrade testcafe to 3.7.6 in Sauce Cloud config and package.json

### DIFF
--- a/saucectl/testcafe/.sauce/config-ex1.yml
+++ b/saucectl/testcafe/.sauce/config-ex1.yml
@@ -14,7 +14,7 @@ sauce:
 
 # Testcafe specific info
 testcafe:
-  version: 3.7.2
+  version: 3.7.6
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 

--- a/saucectl/testcafe/.sauce/config-ex2.yml
+++ b/saucectl/testcafe/.sauce/config-ex2.yml
@@ -14,7 +14,7 @@ sauce:
 
 # Testcafe specific info
 testcafe:
-  version: 3.7.2
+  version: 3.7.6
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 

--- a/saucectl/testcafe/.sauce/config-ex3.yml
+++ b/saucectl/testcafe/.sauce/config-ex3.yml
@@ -14,7 +14,7 @@ sauce:
 
 # Testcafe specific info
 testcafe:
-  version: 3.7.2
+  version: 3.7.6
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 

--- a/saucectl/testcafe/.sauce/config-ex4.yml
+++ b/saucectl/testcafe/.sauce/config-ex4.yml
@@ -14,7 +14,7 @@ sauce:
 
 # Testcafe specific info
 testcafe:
-  version: 3.7.2
+  version: 3.7.6
 # Controls what files are available in the context of a test run (unless explicitly excluded by .sauceignore).
 rootDir: ./
 

--- a/saucectl/testcafe/package-lock.json
+++ b/saucectl/testcafe/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "saucectl": "^0.212.0",
-        "testcafe": "^3.7.2"
+        "testcafe": "^3.7.6"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/saucectl/testcafe/package.json
+++ b/saucectl/testcafe/package.json
@@ -19,6 +19,6 @@
   "license": "MIT",
   "devDependencies": {
     "saucectl": "^0.212.0",
-    "testcafe": "^3.7.2"
+    "testcafe": "^3.7.6"
   }
 }


### PR DESCRIPTION
## Summary
- #477 bumped `package-lock.json`'s resolved testcafe version to 3.7.6, but the `.sauce/config-ex*.yml` runner version (the version Sauce Cloud actually runs) stayed pinned at 3.7.2, and `package.json`'s constraint was never bumped either. This finishes that upgrade.
- Bumps `testcafe.version` to `3.7.6` in all four `.sauce/config-ex*.yml` files.
- Bumps `package.json`'s `testcafe` devDependency to `^3.7.6` (lockfile already resolved there).

## Context
When 3.7.6 was previously tried against the Sauce Cloud runner (during #477), it surfaced intermittent click-triggered navigation failures in the testcafe suite. That flakiness is now mitigated by the `clickUntilVisible` retry helper merged in #477, so re-attempting the version bump on top of that fix.

## Test plan
- [ ] Confirm the `tests (testcafe, test.sauce.ex1.us)` CI check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)